### PR TITLE
remove hiredis to support SSL connections

### DIFF
--- a/gush.gemspec
+++ b/gush.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.11"
   spec.add_dependency "redis", ">= 3.2", "< 6"
   spec.add_dependency "redis-mutex", "~> 4.0.1"
-  spec.add_dependency "hiredis", "~> 0.6"
   spec.add_dependency "graphviz", "~> 1.2"
   spec.add_dependency "terminal-table", ">= 1.4", "< 3.1"
   spec.add_dependency "paint", "~> 2.2"

--- a/lib/gush.rb
+++ b/lib/gush.rb
@@ -1,7 +1,6 @@
 require "bundler/setup"
 
 require "graphviz"
-require "hiredis"
 require "pathname"
 require "redis"
 require "securerandom"

--- a/lib/gush/version.rb
+++ b/lib/gush/version.rb
@@ -1,3 +1,3 @@
 module Gush
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.2.0'.freeze
 end


### PR DESCRIPTION
Hiredis does not support SSL connections yet. By removing this the Redis connection should use the underlying redis-rb connection which does support SSL. The performance drop may be 10-15% but in our case its acceptable.