### PR TITLE
Add support for redis_ssl_params in Gush configuration

### DIFF
--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -11,7 +11,10 @@ module Gush
       cached = (@@redis_connection.value ||= { url: config.redis_url, connection: nil })
       return cached[:connection] if !cached[:connection].nil? && config.redis_url == cached[:url]
 
-      Redis.new(url: config.redis_url).tap do |instance|
+      redis_options = { url: config.redis_url }
+      redis_options[:ssl_params] = config.redis_ssl_params unless config.redis_ssl_params.empty?
+
+      Redis.new(redis_options).tap do |instance|
         RedisClassy.redis = instance
         @@redis_connection.value = { url: config.redis_url, connection: instance }
       end

--- a/lib/gush/configuration.rb
+++ b/lib/gush/configuration.rb
@@ -1,6 +1,6 @@
 module Gush
   class Configuration
-    attr_accessor :concurrency, :namespace, :redis_url, :ttl, :locking_duration, :polling_interval
+    attr_accessor :concurrency, :namespace, :redis_url, :ttl, :locking_duration, :polling_interval, :redis_ssl_params
 
     def self.from_json(json)
       new(Gush::JSON.decode(json, symbolize_keys: true))
@@ -10,6 +10,7 @@ module Gush
       self.concurrency      = hash.fetch(:concurrency, 5)
       self.namespace        = hash.fetch(:namespace, 'gush')
       self.redis_url        = hash.fetch(:redis_url, 'redis://localhost:6379')
+      self.redis_ssl_params = hash.fetch(:redis_ssl_params, {})
       self.gushfile         = hash.fetch(:gushfile, 'Gushfile')
       self.ttl              = hash.fetch(:ttl, -1)
       self.locking_duration = hash.fetch(:locking_duration, 2) # how long you want to wait for the lock to be released, in seconds
@@ -24,11 +25,13 @@ module Gush
       @gushfile.realpath if @gushfile.exist?
     end
 
+
     def to_hash
       {
         concurrency:      concurrency,
         namespace:        namespace,
         redis_url:        redis_url,
+        redis_ssl_params: redis_ssl_params,
         ttl:              ttl,
         locking_duration: locking_duration,
         polling_interval: polling_interval


### PR DESCRIPTION
- Added `redis_ssl_params` to `Gush::Configuration`, allowing SSL options to be configured separately from `redis_url`.
- Updated `self.redis_connection` to pass `redis_ssl_params` to `Redis.new`, ensuring flexibility in Redis SSL configurations.
- Enables better compatibility with Heroku Redis (self-signed certificates) and AWS ElastiCache (custom CA certificates).
- Maintains backward compatibility by defaulting `redis_ssl_params` to an empty hash.